### PR TITLE
[SDAN-737-fix] - Changed newsroom-core to own repo/branch for testing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
     "build": "webpack --mode production --progress"
   },
   "dependencies": {
-    "newsroom-core": "github:superdesk/newsroom-core#develop"
+    "newsroom-core": "github:BrianMwangi21/newsroom-core#SDAN-737-fix"
   },
   "volta": {
     "node": "14.21.3"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -259,7 +259,7 @@ multidict==6.6.4
     #   aiobotocore
     #   aiohttp
     #   yarl
-newsroom-core @ git+https://github.com/superdesk/newsroom-core.git@develop
+newsroom-core @ git+https://github.com/BrianMwangi21/newsroom-core.git@SDAN-737-fix
     # via -r requirements.in
 oauth2client==4.1.3
     # via flask-oidc-ex


### PR DESCRIPTION
This PR works with this [PR](https://github.com/superdesk/newsroom-core/pull/1370) to test videojs